### PR TITLE
Update to micronaut 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0]
+
+* Update to micronaut 2.0.1
+
 ## [1.5.1] - 2019-08-28
 
 * Add more logs when an error occurs

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 group "be.looorent"
-version "1.5.1"
+version "2.0.0"
 description "Create API middleware to check Authorization headers against Keycloak"
 
 sourceCompatibility = 1.8
@@ -32,7 +32,7 @@ repositories {
 
 def keycloakVersion = "4.1.0.Final"
 def rxJavaVersion = "2.1.16"
-def micronautVersion = "1.0.1"
+def micronautVersion = "2.0.1"
 
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java:$micronautVersion"
@@ -77,7 +77,7 @@ publishing {
         maven(MavenPublication) {
             groupId "be.looorent"
             artifactId "keycloak-micronaut-adapter"
-            version "1.5.0"
+            version "2.0.0"
             from components.java
         }
     }

--- a/src/main/java/be/looorent/micronaut/security/SecurityFilter.java
+++ b/src/main/java/be/looorent/micronaut/security/SecurityFilter.java
@@ -6,7 +6,7 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
-import io.micronaut.http.hateos.JsonError;
+import io.micronaut.http.hateoas.JsonError;
 import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 
@@ -51,7 +51,7 @@ public class SecurityFilter implements HttpServerFilter {
         });
     }
 
-    private Flowable<MutableHttpResponse<Object>> handleAuthenticationFailure(FailedSecurityContext failure) {
+    private Flowable<MutableHttpResponse<JsonError>> handleAuthenticationFailure(FailedSecurityContext failure) {
         return fromCallable(() -> {
             JsonError body = new JsonError(failure.getMessage());
             HttpStatus status = failure.isUnexpected() ? INTERNAL_SERVER_ERROR : UNAUTHORIZED;


### PR DESCRIPTION
This will update to micronaut 2.0.1.
The issue I was having was that `io.micronaut.http.hateos.JsonError` was moved to `io.micronaut.http.hateoas.JsonError`.
I also had an issue due to the return type of `handleAuthenticationFailure`. 

Locally it build and the tests pass.